### PR TITLE
persistent tgt cookies

### DIFF
--- a/lib/casserver/cas.rb
+++ b/lib/casserver/cas.rb
@@ -148,7 +148,8 @@ module CASServer::CAS
       error = "No ticket granting ticket given."
       $LOG.debug error
     elsif tgt = TicketGrantingTicket.find_by_ticket(ticket)
-      if settings.config[:expire_sessions] && Time.now - tgt.created_on > settings.config[:ticket_granting_ticket_expiry]
+      if settings.config[:maximum_session_lifetime] && Time.now - tgt.created_on > settings.config[:maximum_session_lifetime]
+	tgt.destroy
         error = "Your session has expired. Please log in again."
         $LOG.info "Ticket granting ticket '#{ticket}' for user '#{tgt.username}' expired."
       else


### PR DESCRIPTION
As discussed at http://code.google.com/p/rubycas-server/issues/detail?id=108

Btw, should i create any new issues here or there?

Quick summary:
- tgt cookies were using maximum_session_lifetime setting to set cookie expiry which defaulted to 1 month. this means that someone logs in at a public computer and then anyone can access cas clients on that computer for a month :O
- i've removed cookie expiry setting to always make these tickets session based and sorted out validate_ticket_granting_ticket to check maximum_session_lifetime for validation denial and server side deletion of the tgt. previously, server side expiry was being based on settings that don't exist in config.yml

let me know if i goofed anywhere and i'll fix it - otherwise it would be good to get this into trunk
