### PR TITLE
Load paths fixes and tweaks

### DIFF
--- a/bin/rubycas-server
+++ b/bin/rubycas-server
@@ -5,7 +5,7 @@ $KCODE = 'u' if RUBY_VERSION < '1.9'
 
 require 'rubygems'
 
-$: << File.dirname(__FILE__) + "/../lib"
+$:.unshift File.dirname(__FILE__) + "/../lib"
 
 if ARGV.join.match('--debugger')
   require 'ruby-debug' 

--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'bundler/setup'
 
-$: << "#{File.dirname(__FILE__)}/lib"
+$:.unshift "#{File.dirname(__FILE__)}/lib"
 require "casserver"
 
 use Rack::ShowExceptions

--- a/lib/casserver.rb
+++ b/lib/casserver.rb
@@ -1,13 +1,10 @@
 module CASServer; end
 
-$: << File.expand_path(File.dirname(__FILE__) + '/casserver')
-$: << File.expand_path(File.dirname(__FILE__) + '/../vendor/isaac_0.9.1')
-
 require 'active_record'
 require 'active_support'
 require 'sinatra/base'
 require 'logger'
 $LOG = Logger.new(STDOUT)
 
-require 'server'
+require 'casserver/server'
 

--- a/lib/casserver/authenticators/sql_encrypted.rb
+++ b/lib/casserver/authenticators/sql_encrypted.rb
@@ -2,9 +2,7 @@ require 'casserver/authenticators/sql'
 
 require 'digest/sha1'
 require 'digest/sha2'
-
-$: << File.dirname(File.expand_path(__FILE__)) + "/../../../vendor/isaac_0.9.1"
-require 'crypt/ISAAC'
+require 'crypt-isaac'
 
 # This is a more secure version of the SQL authenticator. Passwords are encrypted
 # rather than being stored in plain text.

--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -1,7 +1,4 @@
 require 'sinatra/base'
-
-$: << File.expand_path(File.dirname(__FILE__)) + '/../../vendor/isaac_0.9.1'
-
 require 'casserver/localization'
 require 'casserver/utils'
 require 'casserver/cas'

--- a/resources/config.ru
+++ b/resources/config.ru
@@ -19,7 +19,7 @@ if ::File.exist?("#{$APP_ROOT}/tmp/debug.txt")
   Debugger.start_remote
 end
 
-$: << $APP_ROOT + "/lib"
+$:.unshift $APP_ROOT + "/lib"
 
 require 'casserver/load_picnic'
 require 'picnic'

--- a/tasks/db/migrate.rake
+++ b/tasks/db/migrate.rake
@@ -1,7 +1,7 @@
 namespace :db do
   desc "bring your CAS server database schema up to date (options CONFIG=/path/to/config.yml)"
   task :migrate do |t|
-    $: << File.dirname(__FILE__) + "/../../lib"
+    $:.unshift File.dirname(__FILE__) + "/../../lib"
     
     require 'casserver/server'
     


### PR DESCRIPTION
Hey,

So I saw that both
.../lib/
and
.../lib/casserver/
were being loaded into $:, which seems unnecessary since specifying requires as "casserver/server" instead of "server" is much better since
require "server"
will be skipped if anything before it has required something called "server", wheras "casserver/whatever" is far more unlikely to cause such an issue.

I also changed the instances of
$: << "load/path"
to
$:.unshift "load/path"
since that puts the path at the top of the list instead of at the end, prioritizing it first, and since only casserver.rb and casserver/ exist in /lib/, it's safe to do this.
