### PR TITLE
OmniAuth CAS Compatibility

### DIFF
--- a/lib/casserver.rb
+++ b/lib/casserver.rb
@@ -3,8 +3,23 @@ module CASServer; end
 require 'active_record'
 require 'active_support'
 require 'sinatra/base'
+require 'builder'
 require 'logger'
 $LOG = Logger.new(STDOUT)
 
 require 'casserver/server'
-
+module Tilt
+  class BuilderTemplate < Tilt::Template
+    def evaluate(scope, locals, &block)
+      # Changing indent to 0 to adjust generated xml to play well with OmniAuth CAS strategy. That's tested with Tilt 1.1 only.
+      xml = ::Builder::XmlMarkup.new(:indent => 0)
+      if data.respond_to?(:to_str)
+        locals[:xml] = xml
+        super(scope, locals, &block)
+      elsif data.kind_of?(Proc)
+        data.call(xml)
+      end
+      xml.target!
+    end
+  end
+end


### PR DESCRIPTION
Extra attributes in proxy_validate.builder view were generated with additional spaces and OmniAuth CAS (and upcomnig Devise release, that is using OmniAuth) was not stripping them. This is the fast hack showing how it could be fixed.
