### PR TITLE
Indentation fix

### DIFF
--- a/lib/casserver/authenticators/test.rb
+++ b/lib/casserver/authenticators/test.rb
@@ -11,6 +11,7 @@ class CASServer::Authenticators::Test < CASServer::Authenticators::Base
     raise CASServer::AuthenticatorError, "Username is 'do_error'!" if @username == 'do_error'
 
     @extra_attributes[:test_string] = "testing!"
+    @extra_attributes[:test_utf_string] = "Ютф"
     @extra_attributes[:test_numeric] = 123.45
     @extra_attributes[:test_serialized] = {:foo => 'bar', :alpha => [1,2,3]}
 

--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -651,13 +651,15 @@ module CASServer
       end
     end
 
-    def serialize_extra_attribute(builder, value)
+    def serialize_extra_attribute(builder, key, value)
       if value.kind_of?(String)
-        builder.text! value
+        builder.tag! key, value
       elsif value.kind_of?(Numeric)
-        builder.text! value.to_s
+        builder.tag! key, value.to_s
       else
-        builder.cdata! value.to_yaml
+        builder.tag! key do
+          builder.cdata! value.to_yaml
+        end
       end
     end
   end

--- a/lib/casserver/views/proxy_validate.builder
+++ b/lib/casserver/views/proxy_validate.builder
@@ -3,9 +3,7 @@ if @success
     xml.tag!("cas:authenticationSuccess") do
       xml.tag!("cas:user", @username.to_s)
       @extra_attributes.each do |key, value|
-        xml.tag!(key) do
-          serialize_extra_attribute(xml, value)
-        end
+        serialize_extra_attribute(xml, key, value)
       end
       if @pgtiou
         xml.tag!("cas:proxyGrantingTicket", @pgtiou.to_s)

--- a/lib/casserver/views/service_validate.builder
+++ b/lib/casserver/views/service_validate.builder
@@ -3,9 +3,7 @@ if @success
     xml.tag!("cas:authenticationSuccess") do
       xml.tag!("cas:user", @username.to_s)
       @extra_attributes.each do |key, value|
-        xml.tag!(key) do
-          serialize_extra_attribute(xml, value)
-        end
+        serialize_extra_attribute(xml, key, value)
       end
       if @pgtiou
         xml.tag!("cas:proxyGrantingTicket", @pgtiou.to_s)

--- a/spec/casserver_spec.rb
+++ b/spec/casserver_spec.rb
@@ -111,4 +111,30 @@ describe 'CASServer' do
       page.status_code.should_not == 404
     end
   end
+
+  describe "proxyValidate" do
+    before do
+      load_server(File.dirname(__FILE__) + "/default_config.yml")
+      reset_spec_database
+
+      visit "/login?service="+CGI.escape(@target_service)
+
+      fill_in 'username', :with => VALID_USERNAME
+      fill_in 'password', :with => VALID_PASSWORD
+      
+      click_button 'login-submit'
+
+      page.current_url.should =~ /^#{Regexp.escape(@target_service)}\/?\?ticket=ST\-[1-9rA-Z]+/
+      @ticket = page.current_url.match(/ticket=(.*)$/)[1]
+    end
+
+    it "should have extra attributes in proper format" do
+      visit "/serviceValidate?service=#{CGI.escape(@target_service)}&ticket=#{@ticket}"
+
+      puts page.body
+      page.body.should match("<test_string>testing!</test_string>")
+      page.body.should match("<test_numeric>123.45</test_numeric>")
+      page.body.should match("<test_utf_string>&#1070;&#1090;&#1092;</test_utf_string>")
+    end
+  end
 end


### PR DESCRIPTION
Hello. I've run into this issue due to the choice of CAS client library. It was not rubycase-client, but OmniAuth CAS (https://github.com/intridea/omniauth/tree/master/oa-enterprise). OmniAuth seems to be the right way to simple integration with many authentication providers.

I've give it a try but then the problem occurs. Extra attributes values from rubycas-server were returning with extra line feed (\n) in the beginning and several spaces in the end. After a short investigation I've realized the source of this issue was XML response of `/serviceValidate`. It looked like this:

<pre>
&lt;cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas"&gt;
  &lt;cas:authenticationSuccess&gt;
    &lt;cas:user&gt;spec_user&lt;/cas:user&gt;
    &lt;test_string&gt;
testing!    &lt;/test_string&gt;
    &lt;test_numeric&gt;
123.45    &lt;/test_numeric&gt;
    &lt;test_serialized&gt;
      &lt;![CDATA[--- 
:alpha: 
- 1
- 2
- 3
:foo: bar
]]&gt;
    &lt;/test_serialized&gt;
  &lt;/cas:authenticationSuccess&gt;
&lt;/cas:serviceResponse&gt;
</pre>


You can see extra spaces and line feeds here. They are thrown away in rubycas-client by `YAML.load` - https://github.com/gunark/rubycas-client/blob/master/lib/casclient/responses.rb#L80 however OmniAuth CAS just parses XML without any YAML loading attempts. I've looked through the CAS 2.0 protocol and haven't found any information on attributes types of /serviceValidation except they must be strings.

So I thought that would be good idea to fix this issue. I've made a quick hack (https://github.com/gunark/rubycas-server/pull/34) but that was the wrong way. 

There is a test in this request and no monkeypatching so I hope that could be useful for others.

That's how that XML looks after the patch:

<pre>
&lt;cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas"&gt;
  &lt;cas:authenticationSuccess&gt;
    &lt;cas:user&gt;spec_user&lt;/cas:user&gt;
    &lt;test_string&gt;testing!&lt;/test_string&gt;
    &lt;test_numeric&gt;123.45&lt;/test_numeric&gt;
    &lt;test_serialized&gt;
      &lt;![CDATA[--- 
:foo: bar
:alpha: 
- 1
- 2
- 3
]]&gt;
    &lt;/test_serialized&gt;
  &lt;/cas:authenticationSuccess&gt;
&lt;/cas:serviceResponse&gt;
</pre>
