### PR TITLE
Ssout uri escaping

### DIFF
--- a/lib/casserver/cas.rb
+++ b/lib/casserver/cas.rb
@@ -241,38 +241,25 @@ module CASServer::CAS
   # See http://www.ja-sig.org/wiki/display/CASUM/Single+Sign+Out
   def send_logout_notification_for_service_ticket(st)
     uri = URI.parse(st.service)
-    http = Net::HTTP.new(uri.host, uri.port)
-    #http.use_ssl = true if uri.scheme = 'https'
-
+    uri.path = '/' if uri.path.empty?
     time = Time.now
     rand = CASServer::Utils.random_string
 
-    path = uri.path
-    path = '/' if path.empty?
-
-    req = Net::HTTP::Post.new(path)
-    req.set_form_data(
-      'logoutRequest' => %{<samlp:LogoutRequest ID="#{rand}" Version="2.0" IssueInstant="#{time.rfc2822}">
-<saml:NameID></saml:NameID>
-<samlp:SessionIndex>#{st.ticket}</samlp:SessionIndex>
-</samlp:LogoutRequest>}
-    )
-
     begin
-      http.start do |conn|
-        response = conn.request(req)
-
-        if response.kind_of? Net::HTTPSuccess
-          $LOG.info "Logout notification successfully posted to #{st.service.inspect}."
-          return true
-        else
-          $LOG.error "Service #{st.service.inspect} responed to logout notification with code '#{response.code}'!"
-          return false
-        end
+      response = Net::HTTP.post_form(uri, {'logoutRequest' => URI.escape(%{<samlp:LogoutRequest ID="#{rand}" Version="2.0" IssueInstant="#{time.rfc2822}">
+        <saml:NameID></saml:NameID>
+        <samlp:SessionIndex>#{st.ticket}</samlp:SessionIndex>
+        </samlp:LogoutRequest>})})
+      if response.kind_of? Net::HTTPSuccess
+        $LOG.info "Logout notification successfully posted to #{st.service.inspect}."
+        return true
+      else
+        $LOG.error "Service #{st.service.inspect} responed to logout notification with code '#{response.code}'!"
+        return false
       end
     rescue Exception => e
       $LOG.error "Failed to send logout notification to service #{st.service.inspect} due to #{e}"
-          return false
+      return false
     end
   end
 


### PR DESCRIPTION
Hi, wanted to say thanks for your hard and continuing work on rubycas-server and rubycas-client.

This is part of a pair of pull requests, the other commit being on the rubycas-client side:
https://github.com/jcwilk/rubycas-client/commit/f2e484438001b875ccc81adbb1f9dd9461e7cf0e

Basically, I couldn't get the XML to be transferred/read correctly by rubycas-client, rails 2.2 (didn't test it on later versions) was doing really weird stuff with escaping the <'s of the xml tags and lowercasing things... If I URI.escape'd the XML string though, it worked like a charm. Unfortunately this required escaping on the server and unescaping on the client. I implemented it in the client so it was backwards compatible, but with the server you have to go one way or another so that's not an option.

There was also some weirdness with how the request was constructed and it seemed like SSL support was incomplete and not working, so I fixed/cleaned all that up as well.

-John
