### PR TITLE
Change Gemfile and gemspec to list deps in gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,2 @@
 source "http://rubygems.org"
-gem "activerecord", "~> 3.0.0"
-gem "activesupport", "~> 3.0.0"
-gem "sinatra", "~> 1.0"
-gem "gettext", "~> 2.1.0"
-gem "crypt-isaac", "~> 0.9.1"
-
-group :development do
-  gem "rack-test"
-  gem "capybara"
-  gem "rspec"
-  gem "rspec-core"
-  gem "sqlite3-ruby", "~> 1.3.1", :require => "sqlite3"
-end
+gemspec

--- a/rubycas-server.gemspec
+++ b/rubycas-server.gemspec
@@ -7,12 +7,13 @@ $gemspec = Gem::Specification.new do |s|
   s.homepage = 'http://code.google.com/p/rubycas-server/'
   s.platform = Gem::Platform::RUBY
   s.summary  = %q{Provides single sign-on authentication for web applications using the CAS protocol.}
+  s.description  = %q{Provides single sign-on authentication for web applications using the CAS protocol.}
 
   s.files  = [
     "CHANGELOG", "LICENSE", "README.md", "Rakefile", "setup.rb",
     "bin/*", "db/*", "lib/**/*.rb", "public/**/*", "po/**/*", "mo/**/*", "resources/*.*",
     "tasks/**/*.rake", "vendor/**/*", "script/*", "lib/**/*.erb", "lib/**/*.builder",
-    "rubycas-server.gemspec"
+    "Gemfile", "rubycas-server.gemspec"
   ].map{|p| Dir[p]}.flatten
 
   s.test_files = `git ls-files -- spec`.split("\n")
@@ -28,10 +29,22 @@ $gemspec = Gem::Specification.new do |s|
 For more information on RubyCAS-Server, see http://code.google.com/p/rubycas-server
 
 If you plan on using RubyCAS-Server with languages other than English, please cd into the
-RubyCAS-Server installation directory (where the gem is installed) and type `rake localization:mo` 
+RubyCAS-Server installation directory (where the gem is installed) and type `rake localization:mo`
 to build the LOCALE_LC files.
 
 }
+
+  s.add_dependency("activerecord", "~> 3.0.0")
+  s.add_dependency("activesupport", "~> 3.0.0")
+  s.add_dependency("sinatra", "~> 1.0")
+  s.add_dependency("gettext", "~> 2.1.0")
+  s.add_dependency("crypt-isaac", "~> 0.9.1")
+
+  s.add_development_dependency("rack-test")
+  s.add_development_dependency("capybara")
+  s.add_development_dependency("rspec")
+  s.add_development_dependency("rspec-core")
+  s.add_development_dependency("sqlite3", "~> 1.3.1")
 
   s.rdoc_options = [
     '--quiet', '--title', 'RubyCAS-Server Documentation', '--opname',


### PR DESCRIPTION
Hi there,

Thanks for the CAS server, I just recently put it in a project as a mounted Sinatra app within an existing Rails app and works beautifully.  Had to make these changes to make sure everything hooked up OK.  Will be writing up a blog post on it soon.

These changes just move where the dependencies are listed.  This keeps them consistent and makes sure rubygems knows about the deps you need.

Mikel
