### PR TITLE
Set @pgt_url in serviceValidate

### DIFF
--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -627,7 +627,7 @@ module CASServer
 			@service = clean_service_url(params['service'])
 			@ticket = params['ticket']
 			# optional
-			@pgtUrl = params['pgtUrl']
+			@pgt_url = params['pgtUrl']
 			@renew = params['renew']
 
 			st, @error = validate_service_ticket(@service, @ticket)


### PR DESCRIPTION
The implementation of GET /serviceValidate references @pgt_url, but does not actually set it.  This commit sets @pgt_url from params[:pgtUrl].

(I'd like to have also submitted a test with this, but RubyCAS-Server's test suite doesn't appear to be set up to easily add proxy callback behavior checks.  I can help with that, though, if desired.)
