### PR TITLE
(#118) Relax bundler requirement

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,11 @@
 require 'rubygems'
-require 'bundler/setup'
+
+# Assume all necessary gems are in place if bundler is not installed.
+begin
+  require 'bundler/setup'
+rescue LoadError => e
+  raise e unless e.message =~ /no such file to load -- bundler/
+end
 
 $:.unshift "#{File.dirname(__FILE__)}/lib"
 require "casserver"


### PR DESCRIPTION
Prior to this commit, rubycas-server depended on the bundler gem even
in environments in which the necessary dependencies are already met,
such as some production environments. This forces users to
unnecessarily install bundler, which isn't an option in many
restrictive production environments. With this commit, the bundler
dependency is relaxed so that a failure to load bundler doesn't result
in failure, but rather allows execution to continue under the
assumption that the necessary dependencies are already in place. This
commit should not change any behavior in environments where bundler is
available.
