### PR TITLE
(#120) Remove unnecessary BCrypt dependency

### DIFF
--- a/lib/casserver/authenticators/sql_encrypted.rb
+++ b/lib/casserver/authenticators/sql_encrypted.rb
@@ -3,7 +3,6 @@ require 'casserver/authenticators/sql'
 require 'digest/sha1'
 require 'digest/sha2'
 require 'crypt-isaac'
-require 'bcrypt'
 
 # This is a more secure version of the SQL authenticator. Passwords are encrypted
 # rather than being stored in plain text.


### PR DESCRIPTION
See issue http://code.google.com/p/rubycas-server/issues/detail?id=120

Prior to this commit, the SQLEncrypted authenticator required the
bcrypt gem but never made use of it. This commit removes this
dependency.
