### PR TITLE
Point :translations to the correct location

### DIFF
--- a/lib/casserver/localization.rb
+++ b/lib/casserver/localization.rb
@@ -6,7 +6,7 @@ module CASServer
       mod.module_eval do
         register Sinatra::R18n
         set :default_locale, 'en'
-        set :translations,   './locales'
+        set :translations, File.dirname(__FILE__) + "/../../locales"
       end
     end
   end


### PR DESCRIPTION
Per issue #94, I am submitting this pull request because :translations was being set incorrectly.
