### PR TITLE
Remove dead code

### DIFF
--- a/lib/casserver/authenticators/ldap.rb
+++ b/lib/casserver/authenticators/ldap.rb
@@ -78,8 +78,6 @@ class CASServer::Authenticators::LDAP < CASServer::Authenticators::Base
     # the user. If a :filter was specified in the :ldap config, the filter will be
     # added to the LDAP query for the username.
     def bind_by_username
-      username_attribute = options[:ldap][:username_attribute] || default_username_attribute
-
       @ldap.bind_as(:base => @options[:ldap][:base], :password => @password, :filter => user_filter)
     end
 


### PR DESCRIPTION
Previous to this commit, a local variable was instantiated without
side effects by the looks of it, but never used. As a wild guess, this
code was orphaned by a refactor that moved subsequent code to a
separate method that recreates the same local variable. If this isn't
dead code, then it should be refactored to make more explicit what is
going on.
