### PR TITLE
Add restricted_domain option to Google authenticator

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -282,6 +282,15 @@ database:
 #    username: nil
 #    password: nil
 #
+# If you want to restrict access to only those Google accounts in a
+# particular domain, as might be the case for an organization that
+# uses Google for its domain's e-mail, add the restricted_domain
+# option:
+#
+#authenticator:
+#  class: CASServer::Authenticators::Google
+#  restricted_domain: example.com
+#
 # Note that as with all authenticators, it is possible to use the Google 
 # authenticator alongside other authenticators. For example, CAS can first
 # attempt to validate the account with Google, and if that fails, fall back

--- a/lib/casserver/authenticators/google.rb
+++ b/lib/casserver/authenticators/google.rb
@@ -13,6 +13,11 @@ class CASServer::Authenticators::Google < CASServer::Authenticators::Base
 
     return false if @username.blank? || @password.blank?
 
+    if @options[:restricted_domain]
+      return false if @username.count('@') != 1
+      return false if @username.split('@').last != @options[:restricted_domain]
+    end
+
     auth_data = {
       'Email'   => @username,
       'Passwd'  => @password,


### PR DESCRIPTION
Previous to this commit, the Google authenticator would authenticate
any Google account given proper credentials. This commit introduces
the restricted_domain Google authenticator configuration option in
order to restrict authentication only to those Google accounts for
which both proper credentials are given and the domain of the account
matches the restricted_domain option. If no restricted_domain option
is given, the Google authenticator will have the same behavior as
previous to this commit. This new option would be useful for an 
organization that uses Google accounts to handle the e-mail for their 
domain.
