### PR TITLE
CASServer::Model::Base does not exist anymore

### DIFF
--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -535,7 +535,7 @@ module CASServer
           end
 
           pgts = CASServer::Model::ProxyGrantingTicket.find(:all,
-            :conditions => [ActiveRecord::Base.connection.quote_table_name(CASServer::Model::ServiceTicket.table_name)+".username = ?", tgt.username],
+            :conditions => [CASServer::Model::ServiceTicket.quoted_table_name+".username = ?", tgt.username],
             :include => :service_ticket)
           pgts.each do |pgt|
             $LOG.debug("Deleting Proxy-Granting Ticket '#{pgt}' for user '#{pgt.service_ticket.username}'")


### PR DESCRIPTION
Logout action is broken because of 1a292f4895169e5db1dc6161a73d2da18bb58dee
