### PR TITLE
Add support for allowed_service_ips whitelist.

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -538,3 +538,12 @@ log:
 # convert this to "jsmith".
 
 #downcase_username: true
+
+# If you'd like to limit the service hosts that can use CAS for authentication,
+# add the individual IPs and IP ranges in CIDR notation below. Leaving this
+# setting blank will allow any server to authenticate users via the CAS server
+# and potentially harvest sensitive user information.
+
+#allowed_service_ips:
+#  - 127.0.0.1
+#  - 192.168.0.0/24

--- a/spec/config/default_config.yml
+++ b/spec/config/default_config.yml
@@ -48,3 +48,6 @@ enable_single_sign_out: true
 #maximum_session_lifetime: 172800
 
 #downcase_username: true
+
+allowed_service_ips:
+  - 127.0.0.0/24

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,3 +99,12 @@ def reset_spec_database
   ActiveRecord::Migration.verbose = false
   ActiveRecord::Migrator.migrate("db/migrate")
 end
+
+def get_ticket_for(service, username = 'spec_user', password = 'spec_password')
+  visit "/login?service=#{CGI.escape(service)}"
+  fill_in 'username', :with => username
+  fill_in 'password', :with => password
+  click_button 'login-submit'
+
+  page.current_url.match(/ticket=(.*)$/)[1]
+end


### PR DESCRIPTION
allowed_service_ips can be set in config.yml to limit service
validations to a certain set of IPs or IP ranges. This prevents
just any site from being able to grab potentially sensitive
personal information.
