### PR TITLE
Fix loading order for authenticators

### DIFF
--- a/lib/casserver.rb
+++ b/lib/casserver.rb
@@ -7,8 +7,8 @@ require 'builder' # for XML views
 require 'logger'
 $LOG = Logger.new(STDOUT)
 
-require 'casserver/server'
 require 'casserver/authenticators/base'
+require 'casserver/server'
 
 CASServer::Authenticators.autoload :LDAP, 'casserver/authenticators/ldap.rb'
 CASServer::Authenticators.autoload :ActiveDirectoryLDAP, 'casserver/authenticators/active_directory_ldap/'


### PR DESCRIPTION
First we should load up all authenticators base before we will start loading them in server config.
