### PR TITLE
Removed cannot load such file -- lib/casserver/authenticators/sql_encryp...

### DIFF
--- a/lib/casserver.rb
+++ b/lib/casserver.rb
@@ -12,7 +12,7 @@ CASServer::Authenticators.autoload :LDAP, 'casserver/authenticators/ldap.rb'
 CASServer::Authenticators.autoload :ActiveDirectoryLDAP, 'casserver/authenticators/active_directory_ldap.rb'
 CASServer::Authenticators.autoload :SQL, 'casserver/authenticators/sql.rb'
 CASServer::Authenticators.autoload :Google, 'casserver/authenticators/google.rb'
-CASServer::Authenticators.autoload :SQLEncrypted, 'lib/casserver/authenticators/sql_encrypted.rb'
+CASServer::Authenticators.autoload :SQLEncrypted, 'casserver/authenticators/sql_encrypted.rb'
 CASServer::Authenticators.autoload :ActiveResource, 'casserver/authenticators/active_resource.rb'
 
 require 'casserver/server'


### PR DESCRIPTION
Removed cannot load such file -- lib/casserver/authenticators/sql_encrypted.rb (LoadError) for SqlEncrypted authenticator.
Which is occurring due to wrong CASServer::Authenticators.autoload provided for the SqlEncrypted Authenticator. So i updated that path and using in my current app as well. Working well for me.
![Screen Shot](https://f.cloud.github.com/assets/525937/123333/56081218-6ebb-11e2-8409-4a29d379b66a.png)
