### PR TITLE
Fixed CAS attributes for jasig compatibility

### DIFF
--- a/lib/casserver/views/proxy_validate.builder
+++ b/lib/casserver/views/proxy_validate.builder
@@ -4,8 +4,13 @@ if @success
   xml.tag!("cas:serviceResponse", 'xmlns:cas' => "http://www.yale.edu/tp/cas") do
     xml.tag!("cas:authenticationSuccess") do
       xml.tag!("cas:user", @username.to_s)
-      @extra_attributes.each do |key, value|
-        serialize_extra_attribute(xml, key, value)
+      if @extra_attributes
+        xml.tag!("cas:attributes") do
+          @extra_attributes.each do |key, value|
+            namespace_aware_key = key[0..3]=='cas:' ? key : 'cas:' + key 
+            serialize_extra_attribute(xml, namespace_aware_key, value)
+          end
+        end
       end
       if @pgtiou
         xml.tag!("cas:proxyGrantingTicket", @pgtiou.to_s)

--- a/lib/casserver/views/service_validate.builder
+++ b/lib/casserver/views/service_validate.builder
@@ -4,8 +4,13 @@ if @success
   xml.tag!("cas:serviceResponse", 'xmlns:cas' => "http://www.yale.edu/tp/cas") do
     xml.tag!("cas:authenticationSuccess") do
       xml.tag!("cas:user", @username.to_s)
-      @extra_attributes.each do |key, value|
-        serialize_extra_attribute(xml, key, value)
+      if @extra_attributes
+        xml.tag!("cas:attributes") do
+          @extra_attributes.each do |key, value|
+            namespace_aware_key = key[0..3]=='cas:' ? key : 'cas:' + key 
+            serialize_extra_attribute(xml, namespace_aware_key, value)
+          end
+        end
       end
       if @pgtiou
         xml.tag!("cas:proxyGrantingTicket", @pgtiou.to_s)


### PR DESCRIPTION
Boxed the attributes into cas:attributes element and
made attribute keys namespace aware. This is tested
with jasig java client 3.3-SNAPSHOT and rails
devise_cas_authenticatable version 1.1.4.
