### PR TITLE
Username postfix for ldap_authenticators

### DIFF
--- a/lib/casserver/authenticators/ldap.rb
+++ b/lib/casserver/authenticators/ldap.rb
@@ -57,7 +57,7 @@ class CASServer::Authenticators::LDAP < CASServer::Authenticators::Base
     # Add prefix to username, if :username_prefix was specified in the :ldap config.
     def preprocess_username
       @username = @options[:ldap][:username_prefix] + @username if @options[:ldap][:username_prefix]
-      @username = @username + @options[:ldap][:username_postfix] if @options[:ldap][:user_postfix]
+      @username = @username + @options[:ldap][:username_postfix] if @options[:ldap][:username_postfix]
     end
 
     # Attempt to bind with the LDAP server using the username and password entered by


### PR DESCRIPTION
ldap.rb has a username_prefix, but no username_postfix.

Scenario:
We use authentication based on the userprincipalname (an active directory attribute). Our userprincipalnames follows the syntax user@sub.domain.com. But we use only a partial for login: user@sub. In our large organisation there may be identical samaccountnames in different subdomains like smith@sub1 and smith@sub2.

If we can use a username_postfix = '.domain.com', all works fine: the user can use the short form and the authentication uses the full userprincipalname.
