### PR TITLE
Use bind_address from config

### DIFF
--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -138,7 +138,7 @@ module CASServer
 
     def self.handler_options
       handler_options = {
-        :Host => bind || config[:bind_address],
+        :Host => config[:bind_address] || '0.0.0.0',
         :Port => config[:port] || 443
       }
 


### PR DESCRIPTION
This fix sets the `0.0.0.0` if there is no setting of the bind address configuration.

Bind Address is choices wonderful. however, the function is not enabled on the version up of Sinatra. And, Sinatra set the `localhost` to bind.

Regards,
