### PR TITLE
fix decoding of objectguid

### DIFF
--- a/lib/casserver/authenticators/active_directory_ldap.rb
+++ b/lib/casserver/authenticators/active_directory_ldap.rb
@@ -9,8 +9,9 @@ class CASServer::Authenticators::ActiveDirectoryLDAP < CASServer::Authenticators
 
   def extract_extra_attributes(ldap_entry)
     super(ldap_entry)
-    if @extra_attributes["objectGUID"]
-      @extra_attributes["guid"] = @extra_attributes["objectGUID"].to_s.unpack("H*").to_s
+    objguid = @extra_attributes.keys.detect {|k| k.downcase == :objectguid}
+    if objguid
+      @extra_attributes[:guid] = @extra_attributes[objguid].first.unpack("H*").first
     end
     ldap_entry
   end

--- a/lib/casserver/views/proxy_validate.builder
+++ b/lib/casserver/views/proxy_validate.builder
@@ -7,7 +7,7 @@ if @success
       if @extra_attributes
         xml.tag!("cas:attributes") do
           @extra_attributes.each do |key, value|
-            namespace_aware_key = key[0..3]=='cas:' ? key : 'cas:' + key 
+            namespace_aware_key = key[0..3]=='cas:' ? key : 'cas:' + key.to_s 
             serialize_extra_attribute(xml, namespace_aware_key, value)
           end
         end

--- a/spec/casserver/authenticators/active_directory_spec.rb
+++ b/spec/casserver/authenticators/active_directory_spec.rb
@@ -1,0 +1,67 @@
+# encoding: UTF-8
+require 'spec_helper'
+
+describe "CASServer::Authenticators::ActiveDirectoryLDAP" do
+  before do
+    pending("Skip LDAP test due to missing gems") unless gem_available?("net-ldap")
+
+    if $LOG.nil?
+      load_server('default_config') # a lazy way to make sure the logger is set up
+    end
+    # Trigger autoload to load net ldap
+    CASServer::Authenticators::ActiveDirectoryLDAP
+
+    @ldap_entry = Net::LDAP::Entry.new
+
+    @values = {
+      objectguid: ["K1i\xBB\xC3\xC3\xF0F\xA4\xC8:U\x12+\xCC\xDA"],
+      full_name: ['Bilbo Baggins'],
+      address: ['The Shire']
+    }
+    
+    @guid = "4b3169bbc3c3f046a4c83a55122bccda"
+
+    @ldap_entry.instance_variable_set(:@myhash, @values)
+
+    @ldap = mock(Net::LDAP)
+    @ldap.stub!(:host=)
+    @ldap.stub!(:port=)
+    @ldap.stub!(:encryption)
+    @ldap.stub!(:bind_as).and_return(true)
+    @ldap.stub!(:authenticate).and_return(true)
+    @ldap.stub!(:search).and_return([@ldap_entry])
+
+    Net::LDAP.stub!(:new).and_return(@ldap)
+  end
+
+  describe '#validate' do
+
+    it 'validate with preauthentication and with extra attributes' do
+      auth = CASServer::Authenticators::ActiveDirectoryLDAP.new
+
+      auth_config = HashWithIndifferentAccess.new(
+        :ldap => {
+          :host => "ad.example.net",
+          :port => 389,
+          :base => "dc=example,dc=net",
+          :filter => "(objectClass=person)",
+          :auth_user => "authenticator",
+          :auth_password => "itsasecret"
+        },
+        :extra_attributes => [:full_name, :address, :objectguid]
+      )
+
+      auth.configure(auth_config.merge('auth_index' => 0))
+      auth.validate(
+        :username => 'validusername',
+        :password => 'validpassword',
+        :service =>  'test.service',
+        :request => {}
+      ).should == true
+
+      auth.extra_attributes.should == @values.merge(guid: @guid)
+
+    end
+
+  end
+end


### PR DESCRIPTION
original call was escaping the UTF-8 string in
Ruby 1.9.3+.  Also made the search for objectguid
to be case insensitive.
