### PR TITLE
Move logic for matching users into method

### DIFF
--- a/lib/casserver/authenticators/sql_authlogic.rb
+++ b/lib/casserver/authenticators/sql_authlogic.rb
@@ -56,7 +56,7 @@ class CASServer::Authenticators::SQLAuthlogic < CASServer::Authenticators::SQL
     salt_column     = @options[:salt_column]
 
     log_connection_pool_size
-    results = user_model.find(:all, :conditions => ["#{username_column} = ?", @username])
+    results = matching_users
     user_model.connection_pool.checkin(user_model.connection)
 
     begin
@@ -89,5 +89,11 @@ class CASServer::Authenticators::SQLAuthlogic < CASServer::Authenticators::SQL
     else
       return false
     end
+  end
+
+  protected
+
+  def matching_users
+    user_model.find(:all, :conditions => ["#{username_column} = ?", @username])
   end
 end


### PR DESCRIPTION
This commit moves the logic for matching users in the sql authlogic
authenticator into a separate method for extensibility. This will allow
for a custom authenticator to inherit the sql authlogic class and
override the matching users method with a custom query.
