### PR TITLE
UPD depricated finders

### DIFF
--- a/lib/casserver/authenticators/sql.rb
+++ b/lib/casserver/authenticators/sql.rb
@@ -153,6 +153,6 @@ class CASServer::Authenticators::SQL < CASServer::Authenticators::Base
   end
 
   def matching_users
-    user_model.find(:all, :conditions => ["#{username_column} = ? AND #{password_column} = ?", @username, @password])
+    user_model.where("#{username_column} = ? AND #{password_column} = ?", @username, @password)
   end
 end

--- a/lib/casserver/authenticators/sql_authlogic.rb
+++ b/lib/casserver/authenticators/sql_authlogic.rb
@@ -94,6 +94,6 @@ class CASServer::Authenticators::SQLAuthlogic < CASServer::Authenticators::SQL
   protected
 
   def matching_users
-    user_model.find(:all, :conditions => ["#{username_column} = ?", @username])
+    user_model.where("#{username_column} = ?", @username)
   end
 end

--- a/lib/casserver/authenticators/sql_bcrypt.rb
+++ b/lib/casserver/authenticators/sql_bcrypt.rb
@@ -10,7 +10,7 @@ class CASServer::Authenticators::SQLBcrypt < CASServer::Authenticators::SQL
   protected
 
   def matching_users
-    results = user_model.find(:all, :conditions => ["#{username_column} = ?", @username])
+    results = user_model.where("#{username_column} = ?", @username)
     results.select { |user| BCrypt::Password.new(user.send(password_column.to_sym)) == @password }
   end
 

--- a/lib/casserver/authenticators/sql_encrypted.rb
+++ b/lib/casserver/authenticators/sql_encrypted.rb
@@ -53,7 +53,7 @@ class CASServer::Authenticators::SQLEncrypted < CASServer::Authenticators::SQL
     encrypt_function = @options[:encrypt_function] || 'user.encrypted_password == Digest::SHA256.hexdigest("#{user.encryption_salt}::#{@password}")'
 
     log_connection_pool_size
-    results = user_model.find(:all, :conditions => ["#{username_column} = ?", @username])
+    results = user_model.where("#{username_column} = ?", @username)
     user_model.connection_pool.checkin(user_model.connection)
 
     if results.size > 0

--- a/lib/casserver/authenticators/sql_rest_auth.rb
+++ b/lib/casserver/authenticators/sql_rest_auth.rb
@@ -32,7 +32,7 @@ class CASServer::Authenticators::SQLRestAuth < CASServer::Authenticators::SQLEnc
     username_column = @options[:username_column] || "email"
 
     log_connection_pool_size
-    results = user_model.find(:all, :conditions => ["#{username_column} = ?", @username])
+    results = user_model.where("#{username_column} = ?", @username)
     user_model.connection_pool.checkin(user_model.connection)
 
     if results.size > 0

--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -533,9 +533,7 @@ module CASServer
             st.destroy
           end
 
-          pgts = CASServer::Model::ProxyGrantingTicket.find(:all,
-            :conditions => [CASServer::Model::ServiceTicket.quoted_table_name+".username = ?", tgt.username],
-            :include => :service_ticket)
+          pgts = CASServer::Model::ProxyGrantingTicket.includes(:service_ticket).where(CASServer::Model::ServiceTicket.quoted_table_name+".username = ?", tgt.username)
           pgts.each do |pgt|
             $LOG.debug("Deleting Proxy-Granting Ticket '#{pgt}' for user '#{pgt.service_ticket.username}'")
             pgt.destroy


### PR DESCRIPTION
I'm using rails4 ruby2 psql nginx+unicorn
When submitting empty or wrong credentials, have Internal Server Error in browser and unicorn log shows following:
ActiveRecord::StatementInvalid - PG::ConnectionBad: PQconsumeInput() SSL error: decryption failed or bad record mac
:             SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
              FROM pg_attribute a LEFT JOIN pg_attrdef d
                ON a.attrelid = d.adrelid AND a.attnum = d.adnum
             WHERE a.attrelid = '"users"'::regclass
               AND a.attnum > 0 AND NOT a.attisdropped
             ORDER BY a.attnum
.............
lib/casserver/authenticators/sql_encrypted.rb:56:in `validate'
lib/casserver/server.rb:439:in`block (2 levels) in class:Server'
lib/casserver/server.rb:431:in `each'
lib/casserver/server.rb:431:in`block in class:Server'
.............
Fixing this by UPD depricated finders to where()
