### PR TITLE
Use pry instead of ruby-debug

### DIFF
--- a/bin/rubycas-server
+++ b/bin/rubycas-server
@@ -8,7 +8,7 @@ require 'rubygems'
 $:.unshift File.dirname(__FILE__) + "/../lib"
 
 if ARGV.join.match('--debugger')
-  require 'ruby-debug'
+  require 'pry'
   puts
   puts "=> Debugger Enabled"
 end

--- a/rubycas-server.gemspec
+++ b/rubycas-server.gemspec
@@ -43,6 +43,7 @@ $gemspec = Gem::Specification.new do |s|
   s.add_development_dependency("guard-rspec", "2.0.0")
   s.add_development_dependency("webmock", "~> 1.8")
   s.add_development_dependency("nokogiri", "~> 1.3")
+  s.add_development_dependency("pry")
 
   # pull in os specific FS monitoring lib for guard
   case RUBY_PLATFORM


### PR DESCRIPTION
ruby-debug is not easy to compile in ruby 2.0+, but pry works fine.
