### PR TITLE
Pass along the ?service param when the / is requested

### DIFF
--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -499,7 +499,11 @@ module CASServer
     end
 
     get /^#{uri_path}\/?$/ do
-      redirect "#{config['uri_path']}/login", 303
+      service = if params['service']
+        "?service=#{clean_service_url(params['service'])}"
+      end
+
+      redirect "#{config['uri_path']}/login#{service}", 303
     end
 
 

--- a/spec/casserver_spec.rb
+++ b/spec/casserver_spec.rb
@@ -20,6 +20,19 @@ describe 'CASServer' do
     @target_service = 'http://my.app.test'
   end
 
+  describe "/" do
+    it "redirects to /login" do
+      visit "/"
+      page.current_url.should =~ %r{/login$}
+    end
+
+    it "redirects to /login preserving the ?service= parameter" do
+      visit "/?service=http://foo.bar"
+
+      page.current_url.should =~ %r{/login\?service=http://foo\.bar$}
+    end
+  end
+
   describe "/login" do
     before do
       load_server("default_config")


### PR DESCRIPTION
Hello,

if the the root URL is requested, the `?service=` query string parameter is lost in redirection to `/login`.

I've added a quick fix for this and an associated spec. Care to review if it makes sense to you?

Thanks!

cc: @amedeo @lleirborras @mariherrera
