### PR TITLE
use ConnectionManagement middleware to close database connect

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -7,5 +7,6 @@ require "casserver"
 use Rack::ShowExceptions
 use Rack::Runtime
 use Rack::CommonLogger
+use ActiveRecord::ConnectionAdapters::ConnectionManagement
 
 run CASServer::Server.new


### PR DESCRIPTION
The development log will show warning like

```
DEPRECATION WARNING: Database connections will not be closed automatically, please close your database connection at the end of the thread by calling close on your connection. For example: ActiveRecord::Base.connection.close'
```

It can be resolved by adding a middleware `ActiveRecord::ConnectionAdapters::ConnectionManagement`.

The relative discussion is http://stackoverflow.com/questions/10191531/activerecord-connection-warning-database-connections-will-not-be-closed-automa
