### PR TITLE
Reset database before testing CASServer::CAS

### DIFF
--- a/spec/casserver/cas_spec.rb
+++ b/spec/casserver/cas_spec.rb
@@ -8,6 +8,7 @@ require 'cgi'
 describe CASServer::CAS do
   before do
     load_server("default_config")
+    reset_spec_database
     @klass = Class.new {
       include CASServer::CAS
     }


### PR DESCRIPTION
In some cases tests failed due to missing database. To make sure that the
database is in place we are reseting db after reading config file.
