### PR TITLE
Fix error: undefined local variable or method `user_model' for CASServer...

### DIFF
--- a/lib/casserver/authenticators/sql_encrypted.rb
+++ b/lib/casserver/authenticators/sql_encrypted.rb
@@ -40,14 +40,14 @@ class CASServer::Authenticators::SQLEncrypted < CASServer::Authenticators::SQL
 
   def self.setup(options)
     super(options)
-    user_model.__send__(:include, EncryptedPassword)
+    user_models.each { |auth_index, model| model.__send__(:include, EncryptedPassword) }
   end
 
   def validate(credentials)
     read_standard_credentials(credentials)
     raise_if_not_configured
 
-    user_model = self.class.user_model
+    user_model = self.user_model
 
     username_column = @options[:username_column] || "username"
     encrypt_function = @options[:encrypt_function] || 'user.encrypted_password == Digest::SHA256.hexdigest("#{user.encryption_salt}::#{@password}")'


### PR DESCRIPTION
Hello!
This PR contains fix for error:

```
undefined local variable or method `user_model' for CASServer::Authenticators::SQLEncrypted:Class (NameError)
```

See #219 for more.
