### PR TITLE
logout: Redirect to continue_url when present.

### DIFF
--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -559,7 +559,7 @@ module CASServer
       if @gateway && @service
         redirect @service, 303
       elsif @continue_url
-        render @template_engine, :logout
+        redirect @continue_url, 303
       else
         render @template_engine, :login
       end


### PR DESCRIPTION
Fixes #227, if it is actually a problem.

I had some Mediawiki instances that were affected by this, and redirecting to `@continue_url` did the right thing from the user's perspective.
