### PR TITLE
Accept a "from" parameter in the urls for redirection

### DIFF
--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -304,7 +304,7 @@ module CASServer
 
       # optional params
       @service = clean_service_url(params['service'])
-      @from = params['from']
+      @from = clean_service_url(params['from'])
       @return_url = if @from.blank?
                       @service
                     else
@@ -402,7 +402,7 @@ module CASServer
 
       # 2.2.1 (optional)
       @service = clean_service_url(params['service'])
-      @from = params['from']
+      @from = clean_service_url(params['from'])
       @return_url = if @from.blank?
                       @service
                     else

--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -304,6 +304,12 @@ module CASServer
 
       # optional params
       @service = clean_service_url(params['service'])
+      @from = params['from']
+      @return_url = if @from.blank?
+                      @service
+                    else
+                      @service + @from
+                    end
       @renew = params['renew']
       @gateway = params['gateway'] == 'true' || params['gateway'] == '1'
 
@@ -334,7 +340,7 @@ module CASServer
           elsif tgt && !tgt_error
             $LOG.debug("Valid ticket granting ticket detected.")
             st = generate_service_ticket(@service, tgt.username, tgt)
-            service_with_ticket = service_uri_with_ticket(@service, st)
+            service_with_ticket = service_uri_with_ticket(@return_url, st)
             $LOG.info("User '#{tgt.username}' authenticated based on ticket granting cookie. Redirecting to service '#{@service}'.")
             redirect service_with_ticket, 303 # response code 303 means "See Other" (see Appendix B in CAS Protocol spec)
           elsif @gateway
@@ -396,6 +402,12 @@ module CASServer
 
       # 2.2.1 (optional)
       @service = clean_service_url(params['service'])
+      @from = params['from']
+      @return_url = if @from.blank?
+                      @service
+                    else
+                      @service + @from
+                    end
 
       # 2.2.2 (required)
       @username = params['username']
@@ -470,7 +482,7 @@ module CASServer
             @st = generate_service_ticket(@service, @username, tgt)
 
             begin
-              service_with_ticket = service_uri_with_ticket(@service, @st)
+              service_with_ticket = service_uri_with_ticket(@return_url, @st)
 
               $LOG.info("Redirecting authenticated user '#{@username}' at '#{@st.client_hostname}' to service '#{@service}'")
               redirect service_with_ticket, 303 # response code 303 means "See Other" (see Appendix B in CAS Protocol spec)

--- a/lib/casserver/views/_login_form.erb
+++ b/lib/casserver/views/_login_form.erb
@@ -29,6 +29,7 @@
       <td id="submit-container">
         <input type="hidden" id="lt" name="lt" value="<%= escape_html @lt %>" />
         <input type="hidden" id="service" name="service" value="<%= escape_html @service %>" />
+        <input type="hidden" id="from" name="from" value="<%= escape_html @from %>" />
         <input type="submit" class="button" accesskey="l" value="<%= t.button.login %>"
                tabindex="4" id="login-submit" />
       </td>


### PR DESCRIPTION
the /login url accepts a new parameter that will be combined with service parameter for the user redirection after successful login.

This should fix #194 for real - dynamically setting service_url is a partial solution, but a bad one, because with constantly changing service_urls, the tickets are constantly invalidated (because the new request's service url won't match the previous request's service url).

I'm surprised this wasn't considered in the CAS spec, but I can't find any indication there that the original authors ever considered redirecting the user to a deep url within the project; seems like their assumption was always that the user hits the home page no matter what.

I tried to do this by looking at the Referer header first; that would have been more elegant and not required the users to upgrade their CAS integration gems - but it seems that many browsers do not send the referrer as the source of redirect (or at all) when redirected via 302 status code, so unfortunately we have to be explicit about specifying this.

This replaces pull request #231, not sure why I can't edit that one any more.