### PR TITLE
Use GitHub contributors link for attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Other portions are copyright of their respective authors.
 
 ## Authors
 
-See https://github.com/rubycas/rubycas-server/commits
+See https://github.com/rubycas/rubycas-server/graphs/contributors
 
 ## Installation
 


### PR DESCRIPTION
The commit log of a project often doesn't tell the whole story on contributors. The `contributors` page on GitHub will give a historical overview of all the activity in the repo.
- Link to the contributions page
