### PR TITLE
Use default logging formatter with timestamps.

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -467,6 +467,7 @@ infoline: Powered by <a href="http://rubycas.github.com">RubyCAS-Server</a>
 log:
   file: /var/log/casserver.log
   level: INFO
+  formatter_default: true
 
 
 # If you want full database logging, uncomment this next section.

--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -238,6 +238,7 @@ module CASServer
           #$LOG.close
           $LOG = Logger.new(config[:log][:file])
         end
+        $LOG.formatter = Logger::Formatter.new if config[:log][:formatter_default]
         $LOG.level = Logger.const_get(config[:log][:level]) if config[:log][:level]
       end
 


### PR DESCRIPTION
Timestamped logs make debugging easier.